### PR TITLE
fix: Expose /types declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
       "require": "./react.umd.js"
     },
     "./vanilla": {
-      "types": "./vanilla.js",
+      "import": "./vanilla.js",
       "require": "./vanilla.umd.js"
     },
     "./style.css": {
@@ -98,7 +98,8 @@
       "types": "./svelte/GeocodingControl.svelte.d.ts",
       "svelte": "./svelte/GeocodingControl.svelte"
     },
-    "./svelte/*": "./svelte/*"
+    "./svelte/*": "./svelte/*",
+    "./types": "./types.d.ts"
   },
   "devDependencies": {
     "@maptiler/sdk": "^1.2.0",


### PR DESCRIPTION
## Objective
I need to import types from the file `types.d.ts`. For instance, as stated in this [official documentation](https://docs.maptiler.com/sdk-js/modules/geocoding/api/usage/react/) `import type { MapController } from '@maptiler/geocoding-control/types';`.

## Description
I export the path so typescript know toward which file the import is leading to. So I can import the types defined here.

Note: I also fixed the `vanilla` export, which was wrongly using the attribute `types` instead of `import`, like the other modules.

### Acceptance
I updated the `package.json` locally from the node_modules and this fixed my issue.
