### PR TITLE
GO-681 fixed TypeError

### DIFF
--- a/src/GeocodingControl.svelte
+++ b/src/GeocodingControl.svelte
@@ -279,7 +279,7 @@
   }
 
   // clear selection on edit
-  $: if (!selectFirst) {
+  $: {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     searchValue;
 


### PR DESCRIPTION
GO-681

## Objective
Fix: This error occurs only when you first use reverse geocoding and then write some nonsense to geocoding control (Oops! message) and hit enter

### Acceptance
Tested manually.
