### PR TITLE
GO-698 added flag for exhaustive reverse geocoding

### DIFF
--- a/src/GeocodingControl.svelte
+++ b/src/GeocodingControl.svelte
@@ -110,6 +110,8 @@
 
   export let types: string[] | undefined = undefined;
 
+  export let exhaustiveReverseGeocoding = false;
+
   export let excludeTypes = false;
 
   export let zoom: number | Record<string, number> = ZOOM_DEFAULTS;
@@ -465,7 +467,10 @@
         sp.set("fuzzyMatch", String(fuzzyMatch));
       }
 
-      if (limit !== undefined && (!isReverse || types?.length === 1)) {
+      if (
+        limit !== undefined &&
+        (exhaustiveReverseGeocoding || !isReverse || types?.length === 1)
+      ) {
         sp.set("limit", String(limit));
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,13 @@ export type ControlOptions = {
   types?: string[];
 
   /**
+   * Use `limit` value for reverse geocoding even if `types` is not an array with a single element.
+   * Will work only if enabled on the server.
+   * Default value is `false`.
+   */
+  exhaustiveReverseGeocoding?: boolean;
+
+  /**
    * If set to `true` then use all types except for those listed in `types`.
    * Default value is `false`.
    */


### PR DESCRIPTION
GO-698

## Objective
Added flag for exhaustive reverse geocoding (multiple types with limit > 1)

### Acceptance
Tested manually.
