### PR TITLE
Clear list on pick

### DIFF
--- a/examples/react/main.tsx
+++ b/examples/react/main.tsx
@@ -37,7 +37,9 @@ function App() {
 
   const [clearOnBlur, setClearOnBlur] = useState(false);
 
-  const [clearListOnPick, setClearListOnPick] = useState(true);
+  const [clearListOnPick, setClearListOnPick] = useState(false);
+
+  const [keepListOpen, setKeepListOpen] = useState(false);
 
   const map = useRef<maptilersdk.Map | null>(null);
 
@@ -108,6 +110,7 @@ function App() {
               onResponse={(data) => log("response", data)}
               clearOnBlur={clearOnBlur}
               clearListOnPick={clearListOnPick}
+              keepListOpen={keepListOpen}
               iconsBaseUrl="/icons/"
               enableReverse={reverse}
             />
@@ -138,6 +141,15 @@ function App() {
               onChange={(e) => setClearListOnPick(e.currentTarget.checked)}
             />
             <span className="checkable">Clear list on pick</span>
+          </label>
+
+          <label>
+            <input
+              type="checkbox"
+              checked={keepListOpen}
+              onChange={(e) => setKeepListOpen(e.currentTarget.checked)}
+            />
+            <span className="checkable">Keep the list open</span>
           </label>
 
           <label>

--- a/examples/react/main.tsx
+++ b/examples/react/main.tsx
@@ -31,11 +31,13 @@ function App() {
 
   const consoleRef = useRef<HTMLDivElement | null>(null);
 
-  const [collapsed, setCollapsed] = useState<boolean>(false);
+  const [collapsed, setCollapsed] = useState(false);
 
   const [reverse, setReverse] = useState<EnableReverse>("never");
 
-  const [clearOnBlur, setClearOnBlur] = useState<boolean>(false);
+  const [clearOnBlur, setClearOnBlur] = useState(false);
+
+  const [clearListOnPick, setClearListOnPick] = useState(true);
 
   const map = useRef<maptilersdk.Map | null>(null);
 
@@ -105,6 +107,7 @@ function App() {
               onReverseToggle={(data) => log("reverseToggle", data)}
               onResponse={(data) => log("response", data)}
               clearOnBlur={clearOnBlur}
+              clearListOnPick={clearListOnPick}
               iconsBaseUrl="/icons/"
               enableReverse={reverse}
             />
@@ -126,6 +129,15 @@ function App() {
               onChange={(e) => setClearOnBlur(e.currentTarget.checked)}
             />
             <span className="checkable">Clear on blur</span>
+          </label>
+
+          <label>
+            <input
+              type="checkbox"
+              checked={clearListOnPick}
+              onChange={(e) => setClearListOnPick(e.currentTarget.checked)}
+            />
+            <span className="checkable">Clear list on pick</span>
           </label>
 
           <label>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,11 @@
 
 <h2>React</h2>
 <ul>
-  <li><a href="/examples/react/">Headless (no map, just the control)</a></li>
+  <li>
+    <a href="/examples/react/">
+      Separated React Geocoding Control controlling the Map
+    </a>
+  </li>
 </ul>
 
 <h2>Vanilla JS (UMD)</h2>

--- a/src/GeocodingControl.svelte
+++ b/src/GeocodingControl.svelte
@@ -60,6 +60,8 @@
 
   export let clearOnBlur = false;
 
+  export let clearListOnPick = true;
+
   export let collapsed = false;
 
   export let country: string | string[] | undefined = undefined;
@@ -245,7 +247,10 @@
         );
       }
 
-      listFeatures = undefined;
+      if (clearListOnPick) {
+        listFeatures = undefined;
+      }
+
       markedFeatures = undefined;
       selectedItemIndex = -1;
     }
@@ -521,7 +526,9 @@
 
       if (url === lastSearchUrl) {
         if (byId) {
-          listFeatures = undefined;
+          if (clearListOnPick) {
+            listFeatures = undefined;
+          }
 
           picked = cachedFeatures[0];
         } else {
@@ -547,7 +554,9 @@
       dispatch("response", { url, featureCollection });
 
       if (byId) {
-        listFeatures = undefined;
+        if (clearListOnPick) {
+          listFeatures = undefined;
+        }
 
         picked = featureCollection.features[0];
 

--- a/src/GeocodingControl.svelte
+++ b/src/GeocodingControl.svelte
@@ -60,7 +60,9 @@
 
   export let clearOnBlur = false;
 
-  export let clearListOnPick = true;
+  export let clearListOnPick = false;
+
+  export let keepListOpen = false;
 
   export let collapsed = false;
 
@@ -827,7 +829,7 @@
         <ClearIcon />
       </button>
     </div>
-  {:else if !focusedDelayed}
+  {:else if !focusedDelayed && !keepListOpen}
     {""}
   {:else if listFeatures?.length === 0}
     <div class="no-results">
@@ -835,7 +837,7 @@
 
       <div>{noResultsMessage}</div>
     </div>
-  {:else if focusedDelayed && listFeatures?.length}
+  {:else if listFeatures?.length}
     <ul
       class="options"
       on:mouseleave={() => {

--- a/src/react.ts
+++ b/src/react.ts
@@ -41,6 +41,7 @@ const propertyNames = [
   "clearButtonTitle",
   "clearOnBlur",
   "clearListOnPick",
+  "keepListOpen",
   "collapsed",
   "country",
   "debounceSearch",

--- a/src/react.ts
+++ b/src/react.ts
@@ -40,6 +40,7 @@ const propertyNames = [
   "bbox",
   "clearButtonTitle",
   "clearOnBlur",
+  "clearListOnPick",
   "collapsed",
   "country",
   "debounceSearch",

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,11 +187,18 @@ export type ControlOptions = {
   collapsed?: boolean;
 
   /**
-   * If true, the geocoder control will clear its value when the input blurs.
+   * If `true`, the geocoder control will clear its value when the input blurs.
    *
    * Default value is `false`.
    */
   clearOnBlur?: boolean;
+
+  /**
+   * If `false`, then after picking a result from the list or map the list will be cleared and not re-displayed on input box focus.
+   *
+   * Default value is `true`.
+   */
+  clearListOnPick?: boolean;
 
   /**
    * A function which accepts a Feature in the Carmen GeoJSON format to filter out results from the Geocoding API response before they are included in the suggestions list.

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,11 +194,18 @@ export type ControlOptions = {
   clearOnBlur?: boolean;
 
   /**
-   * If `false`, then after picking a result from the list or map the list will be cleared and not re-displayed on input box focus.
+   * If `true`, then after picking a result from the list or map the list will be cleared and not re-displayed on input box focus.
    *
-   * Default value is `true`.
+   * Default value is `false`.
    */
   clearListOnPick?: boolean;
+
+  /**
+   * Keep the list open even if the control is not focused.
+   *
+   * Default value is `false`.
+   */
+  keepListOpen?: boolean;
 
   /**
    * A function which accepts a Feature in the Carmen GeoJSON format to filter out results from the Geocoding API response before they are included in the suggestions list.


### PR DESCRIPTION
GO-842

## Objective
When clicked outside of the geocoding  box, in some use cases I would like the results to keep on being displayed. Currently they disappear until we focus the gcocidng control  again

## Description
Added options:
```ts
/**
   * If `true`, then after picking a result from the list or map the list will be cleared and not re-displayed on input box focus.
   *
   * Default value is `false`.
   */
  clearListOnPick?: boolean;

  /**
   * Keep the list open even if the control is not focused.
   *
   * Default value is `false`.
   */
  keepListOpen?: boolean;
```


### Acceptance
Tested in the included React example.