### PR TITLE
Fixed doc of `reverseGeocodingLimit`, added backward compatibility of MapTiler SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/geocoding-control",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/geocoding-control",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@turf/bbox": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/geocoding-control",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The Javascript & TypeScript Map Control component for MapTiler Geocoding service. Easy to be integrated into any JavaScript mapping application.",
   "type": "module",
   "author": {

--- a/src/GeocodingControl.svelte
+++ b/src/GeocodingControl.svelte
@@ -556,7 +556,7 @@
         effTypes?.length !== 1
       ) {
         console.warn(
-          "For reverse geocoding when `limit` > 1 then `types` must contain single value.",
+          "For reverse geocoding when limit > 1 then types must contain single value.",
         );
       }
 

--- a/src/maptilersdk.ts
+++ b/src/maptilersdk.ts
@@ -1,12 +1,11 @@
 import * as maptilersdk from "@maptiler/sdk";
 import type * as maplibregl from "maplibre-gl";
 import type { Map } from "maplibre-gl";
+import { name, version } from "../package.json";
 import {
   crateClasses,
   type MapLibreBaseControlOptions,
 } from "./MapLibreBasedGeocodingControl";
-
-import { name, version } from "../package.json";
 
 export { createMapLibreGlMapController } from "./maplibregl-controller";
 
@@ -42,7 +41,7 @@ export class GeocodingControl
   implements maptilersdk.IControl
 {
   onAdd(map: maptilersdk.Map): HTMLElement {
-    map.telemetry.registerModule(name, version);
+    map.telemetry?.registerModule(name, version);
     return super.onAddInt(map as unknown as maplibregl.Map);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -343,7 +343,7 @@ export type ControlOptions = {
    *
    * See also `reverseGeocodingTypes` option.
    *
-   * Default: Value of the `limit` option.
+   * Default: The value of the `limit` option if set. If effective types contain a single value, the default is `1`. In all other cases, this option is not used.
    */
   reverseGeocodingLimit?: number;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -339,11 +339,11 @@ export type ControlOptions = {
 
   /**
    * Limits results for reverse geocoding.
-   * Applied only if effective types contain a single value.
+   * Applied only if value is 1 or effective types contain a single value.
    *
    * See also `reverseGeocodingTypes` option.
    *
-   * Default: Value of the `limit` option if set, otherwise `1`.
+   * Default: Value of the `limit` option.
    */
   reverseGeocodingLimit?: number;
 


### PR DESCRIPTION
Fixed doc of `reverseGeocodingLimit`, added backward compatibility of MapTiler SDK.
