### PR TITLE
RD-1000 Replace throw error with console.error

### DIFF
--- a/src/MapLibreBasedGeocodingControl.ts
+++ b/src/MapLibreBasedGeocodingControl.ts
@@ -288,8 +288,8 @@ export function crateClasses<OPTS extends MapLibreBaseControlOptions>(
       };
 
       if (!props.apiKey) {
-        console.error(
-          "No MapTiler apiKey provided, some or all geocoding requests may fail",
+        console.warn(
+          "No MapTiler Cloud API key was provided, some or all geocoding requests may fail",
         );
       }
 

--- a/src/MapLibreBasedGeocodingControl.ts
+++ b/src/MapLibreBasedGeocodingControl.ts
@@ -288,7 +288,9 @@ export function crateClasses<OPTS extends MapLibreBaseControlOptions>(
       };
 
       if (!props.apiKey) {
-        throw new Error("no apiKey provided");
+        console.error(
+          "No MapTiler apiKey provided, some or all geocoding requests may fail",
+        );
       }
 
       this.#gc = new GeocodingControlComponent({ target: div, props });


### PR DESCRIPTION
Replace throw error with console.error to allow for keyless server setups

RD-1000

## Objective
Currently the geolocation control throws an error and halts execution if no API key is provided. Some server clients use the geocoding control in a keyless fashion. This PR converts the throw to a warning instead.

## Description
`throw new Error()` at `src/MapLibreBasedGeocodingControl.ts:292` converted to `console.warn` 

### Acceptance
Manually tested.
